### PR TITLE
Fix Jindy modules having the wrong parent pom + lock versions

### DIFF
--- a/jindy-api/pom.xml
+++ b/jindy-api/pom.xml
@@ -3,14 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.irenical.maven</groupId>
-    <artifactId>parent-root</artifactId>
-    <version>1.8.2</version>
+    <groupId>org.irenical.jindy</groupId>
+    <artifactId>jindy</artifactId>
+    <version>1.1.4-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.irenical.jindy</groupId>
   <artifactId>jindy-api</artifactId>
-  <version>1.1.4-SNAPSHOT</version>
 
   <name>Jindy API</name>
   <description>Jindy - Configuration API</description>

--- a/jindy-archaius-base/pom.xml
+++ b/jindy-archaius-base/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.irenical.jindy</groupId>
       <artifactId>jindy-api</artifactId>
-      <version>${parent.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>com.netflix.archaius</groupId>

--- a/jindy-archaius-base/pom.xml
+++ b/jindy-archaius-base/pom.xml
@@ -3,14 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.irenical.maven</groupId>
-    <artifactId>parent-root</artifactId>
-    <version>1.8.2</version>
+    <groupId>org.irenical.jindy</groupId>
+    <artifactId>jindy</artifactId>
+    <version>1.1.4-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.irenical.jindy</groupId>
   <artifactId>jindy-archaius-base</artifactId>
-  <version>1.1.4-SNAPSHOT</version>
 
   <name>Jindy Archaius</name>
   <description>A base archaius jindy implementation</description>
@@ -34,7 +32,7 @@
     <dependency>
       <groupId>org.irenical.jindy</groupId>
       <artifactId>jindy-api</artifactId>
-      <version>1.1.3</version>
+      <version>${parent.version}</version>
     </dependency>
     <dependency>
       <groupId>com.netflix.archaius</groupId>

--- a/jindy-commons-base/pom.xml
+++ b/jindy-commons-base/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.irenical.jindy</groupId>
       <artifactId>jindy-api</artifactId>
-      <version>${parent.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-configuration</groupId>

--- a/jindy-commons-base/pom.xml
+++ b/jindy-commons-base/pom.xml
@@ -3,14 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.irenical.maven</groupId>
-    <artifactId>parent-root</artifactId>
-    <version>1.8.2</version>
+    <groupId>org.irenical.jindy</groupId>
+    <artifactId>jindy</artifactId>
+    <version>1.1.4-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.irenical.jindy</groupId>
   <artifactId>jindy-commons-base</artifactId>
-  <version>1.1.3</version>
 
   <name>Jindy Commons Configuration</name>
   <description>A base commons configuration jindy implementation</description>
@@ -34,13 +32,30 @@
     <dependency>
       <groupId>org.irenical.jindy</groupId>
       <artifactId>jindy-api</artifactId>
-      <version>1.1.3</version>
+      <version>${parent.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
       <version>1.10</version>
     </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.1.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>logkit</groupId>
+          <artifactId>logkit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>avalon-framework</groupId>
+          <artifactId>avalon-framework</artifactId>
+        </exclusion>
+      </exclusions>
+      <optional>true</optional>
+    </dependency>
+
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/jindy-commons-impl/pom.xml
+++ b/jindy-commons-impl/pom.xml
@@ -3,14 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.irenical.maven</groupId>
-    <artifactId>parent-root</artifactId>
-    <version>1.8.2</version>
+    <groupId>org.irenical.jindy</groupId>
+    <artifactId>jindy</artifactId>
+    <version>1.1.4-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.irenical.jindy</groupId>
   <artifactId>jindy-commons-impl</artifactId>
-  <version>1.1.4-SNAPSHOT</version>
 
   <name>Jindy Commons Implementation</name>
   <description>A Jindy reference implementation, using Apache's commons configurationn</description>
@@ -34,7 +32,7 @@
     <dependency>
       <groupId>org.irenical.jindy</groupId>
       <artifactId>jindy-commons-base</artifactId>
-      <version>1.1.3</version>
+      <version>${parent.version}</version>
     </dependency>
   </dependencies>
 

--- a/jindy-commons-impl/pom.xml
+++ b/jindy-commons-impl/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.irenical.jindy</groupId>
       <artifactId>jindy-commons-base</artifactId>
-      <version>${parent.version}</version>
+      <version>${project.parent.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <module>jindy-api</module>
     <module>jindy-commons-base</module>
     <module>jindy-archaius-base</module>
+    <module>jindy-commons-impl</module>
   </modules>
 
 </project>


### PR DESCRIPTION
Fixed Jindy modules pointing to the wrong parent (they should point at the parent jindy pom rather than their grandparent) and locked the versions of all modules to the parent's version. I assumed that the latter was okay to do since they all had the same version to begin with, let me know if you don't like it.

Also added commons-logging as an optional dependency in jindy-commons-base, so we don't get that (always unwanted if you're using an SLF4J bridge) dependency unless we specifically ask for it. 
