### PR TITLE
Do nothing on listen / unlisten for commons-configuration implementation

### DIFF
--- a/jindy-commons-base/src/main/java/org/irenical/jindy/commons/CommonsWrapper.java
+++ b/jindy-commons-base/src/main/java/org/irenical/jindy/commons/CommonsWrapper.java
@@ -75,7 +75,7 @@ public class CommonsWrapper implements Config {
 
     @Override
     public float getFloat(String key, float defaultValue) {
-        return getFloat(key, defaultValue);
+        return config.getFloat(key, defaultValue);
     }
 
     @Override

--- a/jindy-commons-base/src/main/java/org/irenical/jindy/commons/CommonsWrapper.java
+++ b/jindy-commons-base/src/main/java/org/irenical/jindy/commons/CommonsWrapper.java
@@ -21,12 +21,12 @@ public class CommonsWrapper implements Config {
     
     @Override
     public void unListen(ConfigChangedCallback callback) {
-        throw new UnsupportedOperationException();
+        // commons configuration is immutable, do nothing
     }
 
     @Override
     public void listen(String key, ConfigChangedCallback callback) {
-        throw new UnsupportedOperationException();
+        // commons configuration is immutable, do nothing
     }
 
     @Override


### PR DESCRIPTION
We don't want to blow up the code of people calling listen() and unListen() when we have a commons-configuration backed config. Since it won't change, there's no need to do anything.

This pull request also fixes a StackOverflowError on the getFloat commons-configuration implementation.
