### PR TITLE
When adding a listener via a method reference it's impossible to remove it

### DIFF
--- a/jindy-archaius-base/pom.xml
+++ b/jindy-archaius-base/pom.xml
@@ -51,6 +51,19 @@
       <artifactId>commons-configuration</artifactId>
       <version>1.8</version>
     </dependency>
+    <!-- TEST -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.8.47</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>

--- a/jindy-archaius-base/src/test/java/org/irenical/jindy/archaius/ArchaiusWrapperTest.java
+++ b/jindy-archaius-base/src/test/java/org/irenical/jindy/archaius/ArchaiusWrapperTest.java
@@ -1,0 +1,51 @@
+package org.irenical.jindy.archaius;
+
+import org.apache.commons.configuration.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ArchaiusWrapperTest {
+
+    private static final String A_PROPERTY = "a.property";
+
+    @Mock
+    Configuration configuration;
+
+    @Test
+    public void testRemovingAPreviouslyAddedLambdaListener() throws Exception {
+        ArchaiusWrapper target = new ArchaiusWrapper(configuration);
+
+        ATestClass testClass = new ATestClass(target);
+
+        testClass.start();
+        testClass.stop();
+
+        target.fire(A_PROPERTY);
+    }
+
+
+    private class ATestClass {
+
+        private final ArchaiusWrapper config;
+
+        ATestClass(ArchaiusWrapper wrapper) {
+            config = wrapper;
+        }
+
+        void start() {
+            config.listen(A_PROPERTY, this::aListener);
+        }
+
+        void stop() {
+            config.unListen(this::aListener);
+        }
+
+        private void aListener() {
+            Assert.fail("This should never be called");
+        }
+    }
+}


### PR DESCRIPTION
As the title mentions it's impossible to remove a listener when it was added using a method reference.

```java
ConfigFactory.getConfig().listen("a.property", this::methodReference);
ConfigFactory.getConfig().unlisten(this::methodReference); // This doesn't work
```

I've added a test case that shows the behaviour.

This isn't really a "bug" per-se, it's more of a flaw in the api design that allows the programmer to shoot himself in the foot.

I'm unsure what the solution should be. We can document the behavior and assume it's unfixable or we can change the API to return a reference to the callback that can be used to do the unlisten call. Those are a few suggestions but I'm sure there are other ways to resolve the problem.